### PR TITLE
Remove Cython runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools>=44.0.0", "Cython>=0.29.21", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     license="MIT",
     packages=['mp2hudcolor'],
     install_requires=[
-        'cython',
     ],
     ext_modules=extensions,
     cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
Cython is only needed to build the wheel, not to run the package. This is handled already by being listed in pyproject.toml